### PR TITLE
Max-Age 0 bugfix

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,7 @@ module.exports = ({ config }) => {
     var options = {
       root: Path.join('/tmp/prismic-images'),
       dotfiles: 'deny',
+      cacheControl: false,
       headers: {
         'x-timestamp': Date.now(),
         'x-sent': true


### PR DESCRIPTION
The `sendFile` function adds the `max-age=0` cache header which prevents services like Cloudflare from caching images properly.
Disabling it fixes the issue.